### PR TITLE
Reject promise if the video throws an error

### DIFF
--- a/src/getBlobDuration.js
+++ b/src/getBlobDuration.js
@@ -6,7 +6,7 @@
 export default async function getBlobDuration(blob) {
   const tempVideoEl = document.createElement('video')
 
-  const durationP = new Promise((resolve, reject) =>
+  const durationP = new Promise((resolve, reject) => {
     tempVideoEl.addEventListener('loadedmetadata', () => {
       // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=642012
       if(tempVideoEl.duration === Infinity) {
@@ -16,15 +16,15 @@ export default async function getBlobDuration(blob) {
           resolve(tempVideoEl.duration)
           tempVideoEl.currentTime = 0
         }
-        tempVideoEl.addEventListener('error', (event) =>
-          reject(event.target.error)
-        )
       }
       // Normal behavior
       else
         resolve(tempVideoEl.duration)
-    }),
-  )
+    })
+    tempVideoEl.addEventListener('error', (event) =>
+      reject(event.target.error)
+    )
+  })
 
   tempVideoEl.src = typeof blob === 'string' || blob instanceof String
     ? blob

--- a/src/getBlobDuration.js
+++ b/src/getBlobDuration.js
@@ -21,9 +21,7 @@ export default async function getBlobDuration(blob) {
       else
         resolve(tempVideoEl.duration)
     })
-    tempVideoEl.addEventListener('error', (event) =>
-      reject(event.target.error)
-    )
+    tempVideoEl.onerror = (event) => reject(event.target.error)
   })
 
   tempVideoEl.src = typeof blob === 'string' || blob instanceof String

--- a/src/getBlobDuration.js
+++ b/src/getBlobDuration.js
@@ -6,7 +6,7 @@
 export default async function getBlobDuration(blob) {
   const tempVideoEl = document.createElement('video')
 
-  const durationP = new Promise(resolve =>
+  const durationP = new Promise((resolve, reject) =>
     tempVideoEl.addEventListener('loadedmetadata', () => {
       // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=642012
       if(tempVideoEl.duration === Infinity) {
@@ -16,6 +16,9 @@ export default async function getBlobDuration(blob) {
           resolve(tempVideoEl.duration)
           tempVideoEl.currentTime = 0
         }
+        tempVideoEl.addEventListener('error', (event) =>
+          reject(event.target.error)
+        )
       }
       // Normal behavior
       else

--- a/test/getBlobDuration.test.js
+++ b/test/getBlobDuration.test.js
@@ -11,11 +11,8 @@ beforeEach(() => {
   dummyVideoEl = jest.fn()
 
   dummyVideoEl.addEventListener = jest.fn((eventName, handler) => {
-    if(eventName === 'error') {
-      dummyVideoEl.error = () => handler(dummyErrorEventObject)
-    } else {
-      handler();
-    }
+    expect(eventName).toBe('loadedmetadata')
+    handler()
   })
 
   document.createElement = jest.fn(elType => {
@@ -66,6 +63,6 @@ it('should reject with the error object if an error occurs', async () => {
 
   // noinspection ES6MissingAwait
   const durationP = getBlobDuration(mockBlob)
-  dummyVideoEl.error()
+  dummyVideoEl.onerror(dummyErrorEventObject)
   expect(durationP).rejects.toMatch(dummyErrorEventObject.target.error)
 })

--- a/test/getBlobDuration.test.js
+++ b/test/getBlobDuration.test.js
@@ -64,5 +64,5 @@ it('should reject with the error object if an error occurs', async () => {
   // noinspection ES6MissingAwait
   const durationP = getBlobDuration(mockBlob)
   dummyVideoEl.onerror(dummyErrorEventObject)
-  expect(durationP).rejects.toMatch(dummyErrorEventObject.target.error)
+  await expect(durationP).rejects.toMatch(dummyErrorEventObject.target.error)
 })


### PR DESCRIPTION
Hello! Thanks for authoring and maintaining this package!

In our project, we've run into an issue where we're using it to get the length of user-uploaded files and sometimes they are uploaded with the codecs that the browser can't handle. In this case, video element errors out, but since this error isn't exposed anywhere, it fails silently and just breaks things.

This PR addressese this issue that will hopefully be useful in other cases as well. An error listener is added to the temporary video element that rejects the promise with the error object. This way, consumers can try-catch this function and handle any errors.

Also updated the tests accordingly.

Please let me know if I can change something about my contribution to make it a better fit or if you have any additional questions.